### PR TITLE
Fix docker push on CI

### DIFF
--- a/.github/workflows/docker-ghcr.yml
+++ b/.github/workflows/docker-ghcr.yml
@@ -15,6 +15,10 @@ on:
       - .github/workflows/docker-ghcr.yml
       - Dockerfile
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build_and_push:
     runs-on: ubuntu-latest


### PR DESCRIPTION
https://github.com/sue445/sashimi_tanpopo/actions/runs/18617756636

```
Error: buildx failed with: ERROR: failed to build: denied: installation not allowed to Create organization package
```