### PR TITLE
Revert "Bump major version in gemspec with dependabot :dependabot:"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,13 +10,3 @@ updates:
       default-days: 7
     assignees:
       - sue445
-
-  - package-ecosystem: bundler
-    directory: /
-    schedule:
-      interval: monthly
-    cooldown:
-      default-days: 7
-    assignees:
-      - sue445
-    versioning-strategy: widen


### PR DESCRIPTION
for dependabot error 😢 

> The property '#/updates/1/versioning-strategy' value "widen" did not match one of the following values: lockfile-only, auto, increase, increase-if-necessary

<img width="1220" height="615" alt="image" src="https://github.com/user-attachments/assets/603432e6-598a-49ec-b97c-81863b16a90f" />

Reverts sue445/sashimi_tanpopo#63
