### PR TITLE
Fixes Docker image was not pushed to ghcr.io (TAKE 3)

### DIFF
--- a/.github/workflows/release_gem.yml
+++ b/.github/workflows/release_gem.yml
@@ -54,6 +54,10 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      packages: write
+
     steps:
       - name: Checkout
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0


### PR DESCRIPTION
https://github.com/sue445/sashimi_tanpopo/actions/runs/20000584669/job/57355233442

```
 > pushing ghcr.io/sue445/sashimi_tanpopo:v0.5.2 with docker:
------
ERROR: failed to build: denied: installation not allowed to Write organization package
```