### PR TITLE
ci: `app-id` is deprecated

### DIFF
--- a/.github/workflows/release_gem.yml
+++ b/.github/workflows/release_gem.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: app-token
         with:
-          app-id: ${{ secrets.GH_APP_ID }}
+          client-id: ${{ secrets.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
```
Input 'app-id' has been deprecated with message: Use 'client-id' instead.
```

ref. https://github.com/actions/create-github-app-token/releases/tag/v3.1.0